### PR TITLE
Fix: copy bundle resources

### DIFF
--- a/App/Feeds/Feeds.xcodeproj/project.pbxproj
+++ b/App/Feeds/Feeds.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		0225677123533DA10094BE54 /* SomariKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0225677023533DA10094BE54 /* SomariKit.framework */; };
 		022F868323549A6C00F49A9B /* SomariSandboxKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 022F868223549A6C00F49A9B /* SomariSandboxKit.framework */; };
 		022F868423549A6C00F49A9B /* SomariSandboxKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 022F868223549A6C00F49A9B /* SomariSandboxKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		026CB717237057FC0086A5CB /* FeedsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021B97E7235252EF00E59F3F /* FeedsViewController.xib */; };
 		02DDF799235F03EE00C82F92 /* DummyFeedItemCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DDF798235F03EE00C82F92 /* DummyFeedItemCacheService.swift */; };
 /* End PBXBuildFile section */
 
@@ -350,6 +351,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				026CB717237057FC0086A5CB /* FeedsViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/App/Login/Login.xcodeproj/project.pbxproj
+++ b/App/Login/Login.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		021B97A02351EC5100E59F3F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021B97962351EC3E00E59F3F /* LoginViewController.swift */; };
 		021B97A82351EF3200E59F3F /* LoginGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021B97A72351EF3200E59F3F /* LoginGateway.swift */; };
 		021B97AB2351EF4300E59F3F /* SomariFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 021B97AA2351EF4300E59F3F /* SomariFoundation.framework */; };
+		026CB716237057F30086A5CB /* LoginViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021B97972351EC3E00E59F3F /* LoginViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -231,6 +232,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				026CB716237057F30086A5CB /* LoginViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Login, FeedsモジュールのBuild Phases > Copy Bundle ResourcesにResourceファイルが指定されてないせいでFrameworkにResourceファイルが追加されず、SomariモジュールのBuild Phases > Copy Bundle Resources(Release only)でコピーに失敗し、ビルドに失敗する問題の修正